### PR TITLE
Update AdminTemplateColumns.css

### DIFF
--- a/AdminTemplateColumns.css
+++ b/AdminTemplateColumns.css
@@ -1,18 +1,31 @@
-#Inputfield_admin_column_right {
-	float: right;
+
+.Inputfields li[class*='Inputfield_admin_column_right'] {
+    float: right;
 }
 
-#Inputfield_admin_column_left, #Inputfield_admin_column_right {
-	display: inline-block;
-	clear: none;
-	margin-top: 0;
+.Inputfields li[class*='Inputfield_admin_column_right'],
+.Inputfields li[class*='Inputfield_admin_column_left']{
+    display: inline-block;
+    clear: none;
+    margin-top: 0!important;
 }
 
-#Inputfield_admin_column_left > label, #Inputfield_admin_column_right > label {
-	display: none;
+.Inputfields li[class*='Inputfield_admin_column_right'] > div.ui-widget-content,
+.Inputfields li[class*='Inputfield_admin_column_right'] > div.InputfieldContent,
+.Inputfields li[class*='Inputfield_admin_column_left'] > div.ui-widget-content,
+.Inputfields li[class*='Inputfield_admin_column_left'] > div.InputfieldContent {
+    border: none;
+    padding: 0;
 }
-#Inputfield_admin_column_left > div, #Inputfield_admin_column_right > div {
-	background: none;
-	border: none;
-	padding: 0;
+
+.Inputfields li[class*='Inputfield_admin_column_right'] > div.ui-widget-content,
+.Inputfields li[class*='Inputfield_admin_column_right'] > div.InputfieldContent{
+    margin-left: 0px!important;
 }
+
+.Inputfields li[class*='Inputfield_admin_column_right'] > label,
+.Inputfields li[class*='Inputfield_admin_column_left'] > label {
+    display: none;
+}
+
+


### PR DESCRIPTION
I adapted this css a little to also work for within repeaters, also I have hard time understanding why float:right and display: inline-block is in there as it doesn't seem to be needed and do anything. Those are already floated.

Also wanted to mention that 70 - 29% isn't really doing anything, as PW does change value to round up to 30% anyway...

I also added a margin-left: 0px!important, as the line in the new admin theme overlapped and as there's a margin-left: -1px in the admin theme... lots of strange thing I'm not wanting to get into detail as I lost it already what is currently happening to all those wierd changed and stuff going on int he admin css.
